### PR TITLE
Add ClusterRole for kubevirt rbac.yml

### DIFF
--- a/deploy/rbac.yaml
+++ b/deploy/rbac.yaml
@@ -44,3 +44,17 @@ roleRef:
   kind: Role
   name: kubevirt-operator
   apiGroup: rbac.authorization.k8s.io
+
+---
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: kubevirt-operator
+rules:
+  - apiGroups:
+    - kubevirt.io
+    resources:
+    - "*"
+    verbs:
+    - "*"


### PR DESCRIPTION
The ClusterRole covers all verbs and resources,
we will narrow it down as we go.

Signed-off-by: Ido Rosenzwig <irosenzw@redhat.com>