### PR TITLE
Deploy kubevirt first pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,15 @@ Operator that manages KubeVirt
 
 ### Build the Operator Container
 ```bash
+wget -o https://github.com/kubevirt/kubevirt/releases/download/v0.6.4/kubevirt.yaml
 operator-sdk build docker.io/rthallisey/kubevirt-operator
 ```
 
 ### Launch the Operator
 ```bash
+# Give the kubevirt operator user 'default' cluster-admin privilages
+$ oc adm policy add-cluster-role-to-user cluster-admin -z default
+
 # Deploy the app-operator
 $ kubectl create -f deploy/rbac.yaml
 $ kubectl create -f deploy/crd.yaml

--- a/pkg/stub/handler.go
+++ b/pkg/stub/handler.go
@@ -2,15 +2,13 @@ package stub
 
 import (
 	"context"
+	"os/exec"
+	"strings"
 
 	"github.com/rthallisey/kubevirt-operator/pkg/apis/app/v1alpha1"
 
 	"github.com/operator-framework/operator-sdk/pkg/sdk"
 	"github.com/sirupsen/logrus"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 func NewHandler() sdk.Handler {
@@ -22,47 +20,17 @@ type Handler struct {
 }
 
 func (h *Handler) Handle(ctx context.Context, event sdk.Event) error {
-	switch o := event.Object.(type) {
+	switch event.Object.(type) {
 	case *v1alpha1.App:
-		err := sdk.Create(newbusyBoxPod(o))
-		if err != nil && !errors.IsAlreadyExists(err) {
-			logrus.Errorf("failed to create busybox pod : %v", err)
-			return err
+		// Create kubevirt manifest using the client
+		cmd := exec.Command("kubectl", "create", "-f", "/etc/kubevirt/kubevirt.yaml")
+		// Error is outputed in plain text in out
+		out, _ := cmd.CombinedOutput()
+		if strings.Contains(string(out), "Error from server (AlreadyExists)") {
+			logrus.Debugf("Resources from kubevirt.yaml already exist")
+		} else {
+			logrus.Infof(string(out))
 		}
 	}
 	return nil
-}
-
-// newbusyBoxPod demonstrates how to create a busybox pod
-func newbusyBoxPod(cr *v1alpha1.App) *corev1.Pod {
-	labels := map[string]string{
-		"app": "busy-box",
-	}
-	return &corev1.Pod{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Pod",
-			APIVersion: "v1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "busy-box",
-			Namespace: cr.Namespace,
-			OwnerReferences: []metav1.OwnerReference{
-				*metav1.NewControllerRef(cr, schema.GroupVersionKind{
-					Group:   v1alpha1.SchemeGroupVersion.Group,
-					Version: v1alpha1.SchemeGroupVersion.Version,
-					Kind:    "App",
-				}),
-			},
-			Labels: labels,
-		},
-		Spec: corev1.PodSpec{
-			Containers: []corev1.Container{
-				{
-					Name:    "busybox",
-					Image:   "busybox",
-					Command: []string{"sleep", "3600"},
-				},
-			},
-		},
-	}
 }

--- a/tmp/build/Dockerfile
+++ b/tmp/build/Dockerfile
@@ -1,6 +1,13 @@
 FROM alpine:3.6
 
+RUN wget -P /usr/bin http://storage.googleapis.com/kubernetes-release/release/v1.10.7/bin/linux/amd64/kubectl
+RUN chmod 755 /usr/bin/kubectl
+
+RUN mkdir /etc/kubevirt
+COPY kubevirt.yaml /etc/kubevirt/
+
 RUN adduser -D kubevirt-operator
+RUN chown -R kubevirt-operator: /etc/kubevirt
 USER kubevirt-operator
 
 ADD tmp/_output/bin/kubevirt-operator /usr/local/bin/kubevirt-operator


### PR DESCRIPTION
First pass at deploy event

Some things to improve
   - `kubevirt.yaml` is baked into the Dockefile.  We probably don't want to manage another copy of kubevirt.yaml in our operator.
   - You have to give the operator user cluster-admin permissions to create the resources.  Some additional apis in rbac.yaml should fix this.
   - Need to install the kubectl client.
   - Not using the K8s apis to create resources.
