### PR TITLE
Forgot the filename to use with -o

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Operator that manages KubeVirt
 
 ### Build the Operator Container
 ```bash
-wget -o https://github.com/kubevirt/kubevirt/releases/download/v0.6.4/kubevirt.yaml
+wget -o kubevirt.yaml https://github.com/kubevirt/kubevirt/releases/download/v0.6.4/kubevirt.yaml
 operator-sdk build docker.io/rthallisey/kubevirt-operator
 ```
 


### PR DESCRIPTION
`-o` requires a filename.