### PR TITLE
Delete kubevirt resources first pass

### DIFF
--- a/pkg/stub/handler.go
+++ b/pkg/stub/handler.go
@@ -22,8 +22,23 @@ type Handler struct {
 func (h *Handler) Handle(ctx context.Context, event sdk.Event) error {
 	switch event.Object.(type) {
 	case *v1alpha1.App:
+		kv_yaml := "/etc/kubevirt/kubevirt.yaml"
+		kcmd := "kubectl"
+
+		// According to https://github.com/operator-framework/operator-sdk/issues/270
+		// Deleted field will be removed from event
+		if event.Deleted {
+			// According to https://kubernetes.io/docs/concepts/workloads/controllers/garbage-collection/#background-cascading-deletion
+			// we could rely on background cascading deletion for kubevirt dependent objects
+			// if metadata.ownerReferences field is properly set on them.
+			cmd := exec.Command(kcmd, "delete", "-f", kv_yaml, "--cascade=true")
+			out, _ := cmd.CombinedOutput()
+			logrus.Infof(string(out))
+			return nil
+		}
+
 		// Create kubevirt manifest using the client
-		cmd := exec.Command("kubectl", "create", "-f", "/etc/kubevirt/kubevirt.yaml")
+		cmd := exec.Command(kcmd, "create", "-f", kv_yaml)
 		// Error is outputed in plain text in out
 		out, _ := cmd.CombinedOutput()
 		if strings.Contains(string(out), "Error from server (AlreadyExists)") {


### PR DESCRIPTION
React to events with event.Delete==true (deprecated???)
Rely on ownerReferences for garbage collection.

First attempt as a draft for discussion!